### PR TITLE
Add Mod Loading Priorities, Premain Entry, and Improve Hook

### DIFF
--- a/src/main/kotlin/club/maxstats/weave/loader/api/Hook.kt
+++ b/src/main/kotlin/club/maxstats/weave/loader/api/Hook.kt
@@ -2,12 +2,28 @@ package club.maxstats.weave.loader.api
 
 import org.objectweb.asm.tree.ClassNode
 
-abstract class Hook(val targetClassName: String) {
+abstract class Hook {
+    val targetClassesName: List<String>?
+    val check: ((ByteArray) -> Boolean)?
+
+    constructor(targetClassName: String) {
+        targetClassesName = listOf(targetClassName)
+        check = null
+    }
+
+    constructor(targetClassesName: List<String>) {
+        this.targetClassesName = targetClassesName
+        check = null
+    }
+
+    constructor(check: (ByteArray) -> Boolean) {
+        targetClassesName = null
+        this.check = check
+    }
 
     abstract fun transform(node: ClassNode, cfg: AssemblerConfig)
 
     abstract class AssemblerConfig {
         abstract fun computeFrames()
     }
-    
 }

--- a/src/main/kotlin/club/maxstats/weave/loader/api/HookManager.kt
+++ b/src/main/kotlin/club/maxstats/weave/loader/api/HookManager.kt
@@ -39,13 +39,12 @@ class HookManager {
     )
 
     internal inner class Transformer : SafeTransformer {
-
         override fun transform(
             loader: ClassLoader,
             className: String,
             originalClass: ByteArray
         ): ByteArray? {
-            val hooks = hooks.filter { it.targetClassName == className }
+            val hooks = hooks.filter { it.targetClassesName?.contains(className) ?: (it.check?.invoke(originalClass) ?: error("Can't filter hook at class $className")) }
             if (hooks.isEmpty()) return null
 
             val node = ClassNode()

--- a/src/main/kotlin/club/maxstats/weave/loader/api/ModInitializer.kt
+++ b/src/main/kotlin/club/maxstats/weave/loader/api/ModInitializer.kt
@@ -1,7 +1,5 @@
 package club.maxstats.weave.loader.api
 
 interface ModInitializer {
-
     fun preInit(hookManager: HookManager)
-
 }

--- a/src/main/kotlin/club/maxstats/weave/loader/api/Priority.kt
+++ b/src/main/kotlin/club/maxstats/weave/loader/api/Priority.kt
@@ -1,0 +1,15 @@
+package club.maxstats.weave.loader.api
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Priority(val priority: Priorities)
+
+enum class Priorities(private val priority: Int) {
+    LOWEST(-2),
+    LOW(-1),
+    NORMAL(0),
+    HIGH(1),
+    HIGHEST(2);
+
+    fun getPriority(): Int = priority
+}

--- a/src/main/kotlin/club/maxstats/weave/loader/bootstrap/Agent.kt
+++ b/src/main/kotlin/club/maxstats/weave/loader/bootstrap/Agent.kt
@@ -1,25 +1,89 @@
 package club.maxstats.weave.loader.bootstrap
 
+import club.maxstats.weave.loader.api.Priorities
+import club.maxstats.weave.loader.api.Priority
 import java.lang.instrument.Instrumentation
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.jar.JarFile
+import kotlin.io.path.*
+
+private var initialised = false
+private lateinit var modList: List<Class<*>>
 
 @Suppress("UNUSED_PARAMETER")
 fun premain(opt: String?, inst: Instrumentation) {
     inst.addTransformer(object : SafeTransformer {
         override fun transform(loader: ClassLoader, className: String, originalClass: ByteArray): ByteArray? {
+            if (!initialised) {
+                modList = getModList(inst, loader)
+                initialised = true
+            }
+
             if (className.startsWith("net/minecraft/")) {
                 inst.removeTransformer(this)
-                
-                /* 
+
+                /*
                  * Load the rest of the loader using Lunar's own class loader.
-                 * This allows us access to Minecraft's classes throughout the project.
+                 * This allows us to access to Minecraft's classes throughout the project.
                  */
 
                 loader.loadClass("club.maxstats.weave.loader.WeaveLoader")
-                    .getDeclaredMethod("preInit", Instrumentation::class.java, ClassLoader::class.java)
-                    .invoke(null, inst, loader)
+                    .getDeclaredMethod("preInit", Instrumentation::class.java, ClassLoader::class.java, List::class.java)
+                    .invoke(null, inst, loader, modList)
             }
 
             return null
         }
     })
+}
+
+private fun getModList(inst: Instrumentation, classLoader: ClassLoader) =
+    getOrCreateModDirectory()
+        .listDirectoryEntries("*.jar")
+        .asSequence()
+        .filter { it.isRegularFile() }
+        .map { it.toFile() }
+        .map { modFile ->
+            println("[Weave] Preloading ${modFile.name}")
+            val jar = JarFile(modFile)
+
+            val premainClass = jar.manifest.mainAttributes.getValue("Weave-Premain-Class")
+
+            inst.appendToSystemClassLoaderSearch(jar)
+
+            if (premainClass != null) {
+                try {
+                    classLoader.loadClass(premainClass)
+                        .getDeclaredMethod("premain", Instrumentation::class.java)
+                        .invoke(null, inst)
+                } catch (e: Exception) {
+                    error("Failed to load premainClass $premainClass: ${e.message}")
+                }
+            }
+
+            val entry = jar.manifest.mainAttributes
+                .getValue("Weave-Entry")
+                ?: if (premainClass == null) error("Weave-Entry not defined in ${modFile.name}") else return@map null
+
+            val entryClass = classLoader.loadClass(entry) ?: error("$entry does not exist")
+
+            val loadPriority = entryClass
+                .getAnnotation(Priority::class.java)
+                ?.priority
+                ?: Priorities.NORMAL
+
+            entryClass to loadPriority
+        }
+        .filterNotNull()
+        .sortedByDescending { it.second.getPriority() }
+        .map { it.first }
+        .toList()
+
+private fun getOrCreateModDirectory(): Path {
+    val dir = Paths.get(System.getProperty("user.home"), ".lunarclient", "mods")
+    if (dir.exists() && !dir.isDirectory()) Files.delete(dir)
+    if (!dir.exists()) dir.createDirectory()
+    return dir
 }

--- a/src/main/kotlin/club/maxstats/weave/loader/bootstrap/Agent.kt
+++ b/src/main/kotlin/club/maxstats/weave/loader/bootstrap/Agent.kt
@@ -14,13 +14,13 @@ private lateinit var modList: List<Class<*>>
 
 @Suppress("UNUSED_PARAMETER")
 fun premain(opt: String?, inst: Instrumentation) {
+    if (!initialised) {
+        modList = getModList(inst)
+        initialised = true
+    }
+
     inst.addTransformer(object : SafeTransformer {
         override fun transform(loader: ClassLoader, className: String, originalClass: ByteArray): ByteArray? {
-            if (!initialised) {
-                modList = getModList(inst, loader)
-                initialised = true
-            }
-
             if (className.startsWith("net/minecraft/")) {
                 inst.removeTransformer(this)
 
@@ -39,7 +39,7 @@ fun premain(opt: String?, inst: Instrumentation) {
     })
 }
 
-private fun getModList(inst: Instrumentation, classLoader: ClassLoader) =
+private fun getModList(inst: Instrumentation) =
     getOrCreateModDirectory()
         .listDirectoryEntries("*.jar")
         .asSequence()
@@ -47,6 +47,8 @@ private fun getModList(inst: Instrumentation, classLoader: ClassLoader) =
         .map { it.toFile() }
         .map { modFile ->
             println("[Weave] Preloading ${modFile.name}")
+            val classLoader = ClassLoader.getSystemClassLoader()
+
             val jar = JarFile(modFile)
 
             val premainClass = jar.manifest.mainAttributes.getValue("Weave-Premain-Class")


### PR DESCRIPTION
## Mod Loading Priorities
add `@club.maxstats.weave.loader.api.Priority(club.maxstats.weave.loader.api.Priorities.LOWEST|LOW|NORMAL|HIGH|HIGHEST)` in the Weave-Entry class
if no annotation is found, it'll be set to NORMAL

## Premain (call when first load)
add `Weave-Premain-Class` follow by class name in MANIFEST.MF
```kotlin
@JvmStatic
fun premain(inst: Instrumentation) {
   println("PREMAIN CALLED")
}
```
if there is a Premain Class but no Weave-Entry class, it won't throw any error

## Hook
now there are 3 constructors for Hook.kt
`String`(convert to List), `List<String>` -> check by `Hook.targetClassesName?.contains(className)`
`(ByteArray) -> Boolean` -> check by `Hook.check?.invoke(ByteArray)`
