### PR TITLE
Add nicer logging

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,14 @@ kxSer = "1.5.1"
 mappingsUtil = "0.1.3"
 weaveInternals = "1.0.0-b.2"
 gradle-shadow = "8.1.1"
+klog = "0.0.5"
 
 [libraries]
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
+klog = { module = "me.xtrm:klog", version.ref = "klog" }
 mixin = { module = "net.fabricmc:sponge-mixin", version.ref = "mixin" }
 kxSer = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kxSer" }
 mappingsUtil = { module = "io.github.770grappenmaker:mappings-util", version.ref = "mappingsUtil" }

--- a/loader/build.gradle.kts
+++ b/loader/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     maven("https://maven.fabricmc.net/")
 }
 

--- a/loader/build.gradle.kts
+++ b/loader/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("VulnerableLibrariesLocal")
+
 plugins {
     id("config-kotlin")
     id("config-shade")
@@ -5,11 +7,13 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     maven("https://maven.fabricmc.net/")
 }
 
 dependencies {
     shade(project(":api"))
+    shade(libs.klog)
     shade(libs.kxSer)
     shade(libs.bundles.asm)
     shade(libs.weaveInternals)

--- a/loader/src/main/kotlin/net/weavemc/loader/InjectionHandler.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/InjectionHandler.kt
@@ -1,11 +1,12 @@
 package net.weavemc.loader
 
 import com.grappenmaker.mappings.LambdaAwareRemapper
+import me.xtrm.klog.dsl.klog
 import net.weavemc.api.Hook
 import net.weavemc.internals.dump
 import net.weavemc.loader.bootstrap.transformer.SafeTransformer
-import net.weavemc.loader.util.MappingsHandler.remap
 import net.weavemc.loader.util.*
+import net.weavemc.loader.util.MappingsHandler.remap
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
@@ -82,7 +83,7 @@ object InjectionHandler : SafeTransformer {
 
                 runCatching {
                     classWriter.toByteArray().dump(bytecodeOut.absolutePath)
-                }.onFailure { println("Failed to dump bytecode for $bytecodeOut") }
+                }.onFailure { klog.error("Failed to dump bytecode for $bytecodeOut", it) }
             }
 
             return classWriter.toByteArray()
@@ -114,7 +115,7 @@ data class ModHook(
 }
 
 class AssemblerConfigImpl : Hook.AssemblerConfig {
-    var computeFrames = false
+    private var computeFrames = false
 
     override fun computeFrames() {
         computeFrames = true

--- a/loader/src/main/kotlin/net/weavemc/loader/WeaveLoader.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/WeaveLoader.kt
@@ -2,9 +2,7 @@ package net.weavemc.loader
 
 import com.grappenmaker.mappings.ClasspathLoaders
 import com.grappenmaker.mappings.remappingNames
-import me.xtrm.klog.Level
 import me.xtrm.klog.Logger
-import me.xtrm.klog.dsl.klogConfig
 import net.weavemc.api.Hook
 import net.weavemc.api.ModInitializer
 import net.weavemc.internals.GameInfo
@@ -44,11 +42,10 @@ class WeaveLoader(
     }
 
     init {
-        klogConfig {
-            defaultLevel = Level.INFO
-            appenders = mutableListOf(WeaveLogAppender(true))
-        }
-
+//        klogConfig {
+//            defaultLevel = Level.INFO
+//            appenders = mutableListOf(net.weavemcWeaveLogAppender(true))
+//        }
         logger = Logger(WeaveLoader::class.qualifiedName!!)
         logger.info("Initializing Weave")
 
@@ -74,7 +71,6 @@ class WeaveLoader(
             weaveMod.config.entryPoints.forEach { entrypoint ->
                 runCatching {
                     logger.debug("Calling $entrypoint#preInit")
-                    @Suppress("DEPRECATION")
                     instantiate<ModInitializer>(entrypoint)
                 }.onFailure {
                     logger.error("Failed to instantiate $entrypoint#preInit", it)
@@ -141,7 +137,7 @@ class WeaveLoader(
 
     private fun mixinForNamespace(namespace: String) = mixinInstances.getOrPut(namespace) {
         logger.debug("Creating a new MixinLoader for namespace $namespace")
-        val parent = classLoader.backing
+        val parent = classLoader.weaveBacking
         SandboxedMixinLoader(
             parent = parent,
             loader = ClasspathLoaders.fromLoader(parent)

--- a/loader/src/main/kotlin/net/weavemc/loader/WeaveLoader.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/WeaveLoader.kt
@@ -42,10 +42,6 @@ class WeaveLoader(
     }
 
     init {
-//        klogConfig {
-//            defaultLevel = Level.INFO
-//            appenders = mutableListOf(net.weavemcWeaveLogAppender(true))
-//        }
         logger = Logger(WeaveLoader::class.qualifiedName!!)
         logger.info("Initializing Weave")
 

--- a/loader/src/main/kotlin/net/weavemc/loader/WeaveLogAppender.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/WeaveLogAppender.kt
@@ -1,0 +1,92 @@
+package net.weavemc.loader
+
+import me.xtrm.klog.Appender
+import me.xtrm.klog.LogContext
+import me.xtrm.klog.dsl.klog
+import net.weavemc.loader.util.getOrCreateDirectory
+import java.io.FileOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
+
+/**
+ * We have to do a bit of gymnastics to ensure we don't reinitialize our logfile, create two logfiles,
+ * or overwrite stuff we don't want to.
+ *
+ * Since this class is loaded on two different classloaders, we need to pass it some state (here `initialized`)
+ * to determine whether start a new logging session or continue an existing one.
+ *
+ * @param initialized Whether the logger has already been initialized
+ */
+class WeaveLogAppender(
+    initialized: Boolean = false
+) : Appender {
+    private val formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss")
+    private val logDir = getOrCreateDirectory("logs")
+    private val logFile: Path
+
+    private val stdoutStream = WrappingStream(System.out)
+    private val stderrStream = WrappingStream(System.err)
+    private val logFileStream: PrintStream
+
+    private val logger by klog
+
+    init {
+        logFile = fetchLogFile(initialized)
+        logFileStream = PrintStream(FileOutputStream(logFile.toFile(), initialized), true)
+        if (!initialized) {
+            symlinkLatest()
+        }
+    }
+
+    override fun append(context: LogContext, finalMessage: String) {
+        stdoutStream.println(finalMessage)
+        stdoutStream.flush()
+        logFileStream.println(finalMessage)
+        logFileStream.flush()
+
+        val args = context.args
+        if (args.isNotEmpty()) {
+            val last = args.last()
+            if (last is Throwable) {
+                last.printStackTrace(stderrStream)
+                last.printStackTrace(logFileStream)
+            }
+        }
+    }
+
+    private fun symlinkLatest() {
+        val latest = logDir.resolve("latest.log")
+        latest.deleteIfExists()
+        runCatching {
+            Files.createLink(latest, logFile)
+        }.onFailure { e1 ->
+            runCatching {
+                Files.createSymbolicLink(latest, logFile)
+            }.onFailure { e2 ->
+                e1.addSuppressed(e2)
+                logger.error("Failed to create (sym)link to latest log", e1)
+            }
+        }
+    }
+
+    private fun fetchLogFile(initialized: Boolean): Path {
+        val latestLog = logDir.resolve("latest.log")
+        if (!initialized || !latestLog.exists()) {
+            return logDir.resolve("weave-loader-${LocalDateTime.now().format(formatter)}.log")
+        }
+        // If the loader is already initialized, we will just write to the latest log
+        return latestLog
+    }
+
+    internal class WrappingStream(private val stream: PrintStream) : PrintStream(stream) {
+        override fun println(x: Any?) {
+            // Use print with a manual newline to prevent Legacy Forge from redirecting to log4j
+            stream.print("$x\n")
+        }
+    }
+}

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
@@ -11,7 +11,6 @@ import net.weavemc.loader.bootstrap.transformer.ArgumentSanitizer
 import net.weavemc.loader.bootstrap.transformer.ModInitializerHook
 import net.weavemc.loader.bootstrap.transformer.URLClassLoaderTransformer
 import net.weavemc.loader.util.*
-import net.weavemc.loader.util.FileManager.ModJar
 import java.awt.GraphicsEnvironment
 import java.lang.instrument.Instrumentation
 import java.util.jar.JarFile
@@ -62,7 +61,7 @@ private fun callTweakers(inst: Instrumentation) {
         .flatMap(ModConfig::tweakers)
 
     for (tweaker in tweakers) {
-        println("[Weave] Calling tweaker: $tweaker")
+        logger.trace("Calling tweaker: $tweaker")
         instantiate<Tweaker>(tweaker).tweak(inst)
     }
 }

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
@@ -36,7 +36,7 @@ fun premain(opt: String?, inst: Instrumentation) {
     inst.addTransformer(ModInitializerHook(inst))
 
     inst.addTransformer(ArgumentSanitizer, true)
-    inst.retransformClasses(Class.forName("sun.management.RuntimeImpl", false, ClassLoader.getSystemClassLoader()))
+    inst.tryRetransform("sun.management.RuntimeImpl")
     inst.removeTransformer(ArgumentSanitizer)
 
     // Prevent ichor prebake
@@ -48,6 +48,15 @@ fun premain(opt: String?, inst: Instrumentation) {
 
     // initialize bootstrap
     Bootstrap.bootstrap(inst)
+}
+
+private fun Instrumentation.tryRetransform(className: String) {
+    val loadedClass = this.allLoadedClasses.firstOrNull { it.name == className }
+    if (loadedClass == null) {
+        Class.forName(className, false, ClassLoader.getSystemClassLoader())
+    } else {
+        this.retransformClasses(loadedClass)
+    }
 }
 
 private fun callTweakers(inst: Instrumentation) {

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
@@ -51,12 +51,10 @@ fun premain(opt: String?, inst: Instrumentation) {
 }
 
 private fun Instrumentation.tryRetransform(className: String) {
-    val loadedClass = this.allLoadedClasses.firstOrNull { it.name == className }
-    if (loadedClass == null) {
-        Class.forName(className, false, ClassLoader.getSystemClassLoader())
-    } else {
-        this.retransformClasses(loadedClass)
-    }
+    val loadedClasses = this.allLoadedClasses
+    val clazz = Class.forName(className, false, ClassLoader.getSystemClassLoader())
+    if (clazz in loadedClasses)
+        this.retransformClasses(clazz)
 }
 
 private fun callTweakers(inst: Instrumentation) {

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
@@ -6,7 +6,6 @@ import me.xtrm.klog.dsl.klogConfig
 import net.weavemc.api.Tweaker
 import net.weavemc.internals.ModConfig
 import net.weavemc.loader.WeaveLoader
-import net.weavemc.loader.WeaveLogAppender
 import net.weavemc.loader.bootstrap.transformer.ArgumentSanitizer
 import net.weavemc.loader.bootstrap.transformer.ModInitializerHook
 import net.weavemc.loader.bootstrap.transformer.URLClassLoaderTransformer
@@ -25,7 +24,7 @@ private val logger by klog
 fun premain(opt: String?, inst: Instrumentation) {
     klogConfig {
         defaultLevel = Level.INFO
-        appenders = mutableListOf(WeaveLogAppender())
+        appenders = mutableListOf(WeaveLogAppender)
     }
 
     logger.info("Attached Weave")

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
@@ -1,8 +1,12 @@
 package net.weavemc.loader.bootstrap
 
+import me.xtrm.klog.Level
+import me.xtrm.klog.dsl.klog
+import me.xtrm.klog.dsl.klogConfig
 import net.weavemc.api.Tweaker
 import net.weavemc.internals.ModConfig
 import net.weavemc.loader.WeaveLoader
+import net.weavemc.loader.WeaveLogAppender
 import net.weavemc.loader.bootstrap.transformer.ArgumentSanitizer
 import net.weavemc.loader.bootstrap.transformer.ModInitializerHook
 import net.weavemc.loader.bootstrap.transformer.URLClassLoaderTransformer
@@ -12,13 +16,20 @@ import java.awt.GraphicsEnvironment
 import java.lang.instrument.Instrumentation
 import java.util.jar.JarFile
 
+private val logger by klog
+
 /**
  * The JavaAgent's `premain()` method, this is where initialization of Weave Loader begins.
  * Weave Loader's initialization begins by instantiating [WeaveLoader]
  */
 @Suppress("UNUSED_PARAMETER")
 fun premain(opt: String?, inst: Instrumentation) {
-    println("[Weave] Attached Weave")
+    klogConfig {
+        defaultLevel = Level.INFO
+        appenders = mutableListOf(WeaveLogAppender())
+    }
+
+    logger.info("Attached Weave")
 
     setGameInfo()
     callTweakers(inst)
@@ -42,7 +53,7 @@ fun premain(opt: String?, inst: Instrumentation) {
 }
 
 private fun callTweakers(inst: Instrumentation) {
-    println("[Weave] Calling tweakers")
+    logger.info("Calling tweakers")
 
     val tweakers = FileManager
         .getMods()

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Bootstrap.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Bootstrap.kt
@@ -29,10 +29,6 @@ object Bootstrap {
                     val clAccessor = if (loader is URLClassLoaderAccessor) loader
                     else fatalError("Failed to transform URLClassLoader to implement URLClassLoaderAccessor. Impossible to recover")
 
-                    clAccessor.addWeaveIgnoredPackage("net.weavemc.loader.bootstrap")
-                    clAccessor.addWeaveIgnoredPackage("kotlin.")
-                    clAccessor.addWeaveIgnoredPackage("me.xtrm.klog.")
-
                     runCatching {
                         clAccessor.addWeaveURL(javaClass.protectionDomain.codeSource.location)
                     }.onFailure {

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Bootstrap.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/Bootstrap.kt
@@ -29,6 +29,10 @@ object Bootstrap {
                     val clAccessor = if (loader is URLClassLoaderAccessor) loader
                     else fatalError("Failed to transform URLClassLoader to implement URLClassLoaderAccessor. Impossible to recover")
 
+                    clAccessor.addWeaveIgnoredPackage("net.weavemc.loader.bootstrap")
+                    clAccessor.addWeaveIgnoredPackage("kotlin.")
+                    clAccessor.addWeaveIgnoredPackage("me.xtrm.klog.")
+
                     runCatching {
                         clAccessor.addWeaveURL(javaClass.protectionDomain.codeSource.location)
                     }.onFailure {

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/WeaveLogAppender.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/WeaveLogAppender.kt
@@ -1,4 +1,4 @@
-package net.weavemc.loader
+package net.weavemc.loader.bootstrap
 
 import me.xtrm.klog.Appender
 import me.xtrm.klog.LogContext
@@ -22,9 +22,7 @@ import kotlin.io.path.exists
  *
  * @param initialized Whether the logger has already been initialized
  */
-class WeaveLogAppender(
-    initialized: Boolean = false
-) : Appender {
+object WeaveLogAppender : Appender {
     private val formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy_HH-mm-ss")
     private val logDir = getOrCreateDirectory("logs")
     private val logFile: Path
@@ -36,11 +34,9 @@ class WeaveLogAppender(
     private val logger by klog
 
     init {
-        logFile = fetchLogFile(initialized)
-        logFileStream = PrintStream(FileOutputStream(logFile.toFile(), initialized), true)
-        if (!initialized) {
-            symlinkLatest()
-        }
+        logFile = fetchLogFile(false)
+        logFileStream = PrintStream(FileOutputStream(logFile.toFile(), false), true)
+        symlinkLatest()
     }
 
     override fun append(context: LogContext, finalMessage: String) {

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/ApplicationWrapper.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/ApplicationWrapper.kt
@@ -1,5 +1,6 @@
 package net.weavemc.loader.bootstrap.transformer
 
+import me.xtrm.klog.dsl.klog
 import net.weavemc.internals.asm
 import net.weavemc.loader.mixin.LoaderClassWriter
 import net.weavemc.loader.util.asClassNode
@@ -12,7 +13,6 @@ import org.objectweb.asm.tree.LabelNode
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.MethodType
 import java.lang.invoke.WrongMethodTypeException
-import java.net.URL
 import java.net.URLClassLoader
 
 // Makes sure to run the application within some notion of a "custom" ClassLoader,
@@ -66,9 +66,10 @@ object ApplicationWrapper {
     @JvmStatic
     @Suppress("unused")
     fun wrap(targetMain: String, args: Array<String>) {
-        println("[Weave] Minecraft Main was directly invoked, which potentially blocks transformation")
-        println(
-            "[Weave] This is normal to happen on Vanilla Minecraft pre-launchwrapper. " +
+        val logger by klog
+        logger.info("Minecraft Main was directly invoked, which potentially blocks transformation")
+        logger.info(
+            "This is normal to happen on Vanilla Minecraft pre-launchwrapper. " +
                     "Therefore, the game will be wrapped into a new ClassLoader"
         )
 
@@ -83,7 +84,7 @@ object ApplicationWrapper {
                     // Some error occurred within reflective access
                     e.printStackTrace()
 
-                    println("[Weave] Failed to wrap game using java.lang.invoke, using Reflection fallback")
+                    logger.warn("Failed to wrap game using java.lang.invoke, using Reflection fallback")
                     mainClass.getMethod("main", args::class.java)(null, args)
                 }
                 else -> throw e

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/ClassLoaderTransformer.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/ClassLoaderTransformer.kt
@@ -4,14 +4,17 @@ import net.weavemc.internals.asm
 import net.weavemc.internals.internalNameOf
 import net.weavemc.internals.visitAsm
 import net.weavemc.loader.mixin.LoaderClassWriter
-import org.objectweb.asm.*
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.LabelNode
 import java.net.URL
 import java.net.URLClassLoader
 
 interface URLClassLoaderAccessor {
-    val backing: ClassLoader
+    val weaveBacking: ClassLoader
+    fun addWeaveIgnoredPackage(pkg: String)
     fun addWeaveURL(url: URL)
 }
 
@@ -27,6 +30,79 @@ object URLClassLoaderTransformer : SafeTransformer {
         reader.accept(node, 0)
 
         node.interfaces.add(internalNameOf<URLClassLoaderAccessor>())
+
+        // public URLClassLoader getWeaveBacking()
+        node.visitMethod(Opcodes.ACC_PUBLIC, "getWeaveBacking", "()Ljava/lang/ClassLoader;", null, null).visitAsm {
+            aload(0)
+            areturn
+        }
+
+        // private final List<String> weave$ignoredPackages = new ArrayList<>();
+        node.visitField(Opcodes.ACC_PRIVATE or Opcodes.ACC_FINAL, "weave\$ignoredPackages", "Ljava/util/List;", "Ljava/util/List<Ljava/lang/String;>;", null)
+        node.methods.filter { it.name == "<init>" }.forEach { methodNode ->
+            methodNode.instructions.insert(asm {
+                aload(0)
+                new("java/util/ArrayList")
+                dup
+                invokespecial("java/util/ArrayList", "<init>", "()V")
+                putfield(node.name, "weave\$ignoredPackages", "Ljava/util/List;")
+            })
+        }
+        node.visitMethod(Opcodes.ACC_PUBLIC, "addWeaveIgnoredPackage", "(Ljava/lang/String;)V", null, null).visitAsm {
+            aload(0)
+            getfield(node.name, "weave\$ignoredPackages", "Ljava/util/List;")
+            aload(1)
+            invokeinterface("java/util/List", "add", "(Ljava/lang/Object;)Z")
+            pop
+            _return
+        }
+        node.visitMethod(Opcodes.ACC_PRIVATE or Opcodes.ACC_FINAL, "weave\$shouldIgnore", "(Ljava/lang/String;)Z", null, null).visitAsm {
+            val loopStart = LabelNode()
+            val loopEnd = LabelNode()
+
+            getstatic("java/lang/System", "out", "Ljava/io/PrintStream;")
+            aload(1)
+            invokevirtual("java/io/PrintStream", "println", "(Ljava/lang/String;)V")
+
+            // Iterator<String> iter = weave$ignoredPackages.iterator();
+            aload(0)
+            getfield(node.name, "weave\$ignoredPackages", "Ljava/util/List;")
+            invokeinterface("java/util/List", "iterator", "()Ljava/util/Iterator;")
+            astore(2)
+
+            // while (iter.hasNext())
+            +loopStart
+            aload(2)
+            invokeinterface("java/util/Iterator", "hasNext", "()Z")
+            ifeq(loopEnd)
+
+            // if (iter.next().startsWith(pkg))
+            aload(2)
+            invokeinterface("java/util/Iterator", "next", "()Ljava/lang/Object;")
+            checkcast("java/lang/String")
+            astore(3)
+            aload(1)
+            aload(3)
+            invokevirtual("java/lang/String", "startsWith", "(Ljava/lang/String;)Z")
+            ifeq(loopStart)
+
+            // return true
+            getstatic("java/lang/System", "out", "Ljava/io/PrintStream;")
+            ldc("Returning true")
+            invokevirtual("java/io/PrintStream", "println", "(Ljava/lang/String;)V")
+            iconst_1
+            ireturn
+
+            +loopEnd
+            // return false
+            getstatic("java/lang/System", "out", "Ljava/io/PrintStream;")
+            ldc("Returning false")
+            invokevirtual("java/io/PrintStream", "println", "(Ljava/lang/String;)V")
+            iconst_0
+            ireturn
+        }
+
+        // public void addWeaveURL(URL url)
         node.visitMethod(Opcodes.ACC_PUBLIC, "addWeaveURL", "(Ljava/net/URL;)V", null, null).visitAsm {
             aload(0)
             aload(1)
@@ -34,26 +110,22 @@ object URLClassLoaderTransformer : SafeTransformer {
             _return
         }
 
-        node.visitMethod(Opcodes.ACC_PUBLIC, "getBacking", "()Ljava/lang/ClassLoader;", null, null).visitAsm {
-            aload(0)
-            areturn
-        }
-
         val loadClassInject = asm {
-            // TODO: dry
+            val notIgnored = LabelNode()
+
+            // if (weave$shouldIgnore(name))
+            aload(0)
             aload(1)
-            ldc("net.weavemc.loader.bootstrap")
-            invokevirtual("java/lang/String", "startsWith", "(Ljava/lang/String;)Z")
+            invokespecial(node.name, "weave\$shouldIgnore", "(Ljava/lang/String;)Z")
+            ifeq(notIgnored)
 
-            val notBootstrap = LabelNode()
-            ifeq(notBootstrap)
-
+            // return ClassLoader.getSystemClassLoader().loadClass(name);
             invokestatic("java/lang/ClassLoader", "getSystemClassLoader", "()Ljava/lang/ClassLoader;")
             aload(1)
             invokevirtual("java/lang/ClassLoader", "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;")
             areturn
 
-            +notBootstrap
+            +notIgnored
         }
 
         listOf("loadClass", "findClass")

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/SafeTransformer.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/SafeTransformer.kt
@@ -1,6 +1,7 @@
 package net.weavemc.loader.bootstrap.transformer
 
 import me.xtrm.klog.dsl.klog
+import net.weavemc.loader.util.exit
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
 import java.lang.instrument.ClassFileTransformer
@@ -35,6 +36,6 @@ internal interface SafeTransformer : ClassFileTransformer {
         bytes
     }.getOrElse {
         klog.fatal("An error occurred while transforming {} (from {})", className, this.javaClass.name, it)
-        null
+        exit(1)
     }
 }

--- a/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/SafeTransformer.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/bootstrap/transformer/SafeTransformer.kt
@@ -1,12 +1,12 @@
 package net.weavemc.loader.bootstrap.transformer
 
+import me.xtrm.klog.dsl.klog
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
 import java.lang.instrument.ClassFileTransformer
 import java.security.ProtectionDomain
-import kotlin.system.exitProcess
 
-val checkBytecode = java.lang.Boolean.getBoolean("weave.loader.checkTransformedBytecode")
+private val checkBytecode = java.lang.Boolean.getBoolean("weave.loader.checkTransformedBytecode")
 
 internal interface SafeTransformer : ClassFileTransformer {
     /**
@@ -34,8 +34,7 @@ internal interface SafeTransformer : ClassFileTransformer {
         }
         bytes
     }.getOrElse {
-        it.printStackTrace()
-        println("An error occurred while transforming $className (from ${this.javaClass.name}): ${it.message}")
-        exitProcess(1)
+        klog.fatal("An error occurred while transforming {} (from {})", className, this.javaClass.name, it)
+        null
     }
 }

--- a/loader/src/main/kotlin/net/weavemc/loader/mixin/MixinSandbox.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/mixin/MixinSandbox.kt
@@ -62,7 +62,7 @@ class SandboxedMixinLoader(
 
     private val systemClasses = illegalToReload + setOf(
         "kotlin.", "kotlinx.", "org.objectweb.asm.",
-        "net.weavemc.loader.mixin.SandboxedMixinState"
+        "me.xtrm.klog.", "net.weavemc.loader.mixin.SandboxedMixinState"
     )
 
     /**
@@ -106,12 +106,7 @@ class SandboxedMixinLoader(
         }
     }
 
-    override fun loadClass(name: String): Class<*> {
-        if (name.startsWith("me.xtrm.klog.") || name.startsWith("kotlin.")) {
-            return getSystemClassLoader().loadClass(name)
-        }
-        return findClass(name)
-    }
+    override fun loadClass(name: String): Class<*> = findClass(name)
     private fun shouldLoadParent(name: String) = name in loaderExclusions || systemClasses.any { name.startsWith(it) }
 
     /**

--- a/loader/src/main/kotlin/net/weavemc/loader/mixin/Services.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/mixin/Services.kt
@@ -1,13 +1,12 @@
 package net.weavemc.loader.mixin
 
 import me.xtrm.klog.dsl.klog
-import net.weavemc.loader.WeaveLogAppender
+import net.weavemc.loader.bootstrap.WeaveLogAppender
 import net.weavemc.loader.util.asClassNode
 import net.weavemc.loader.util.asClassReader
 import net.weavemc.loader.util.getJavaVersion
 import org.spongepowered.asm.launch.platform.container.ContainerHandleVirtual
 import org.spongepowered.asm.launch.platform.container.IContainerHandle
-import org.spongepowered.asm.logging.ILogger
 import org.spongepowered.asm.logging.Level
 import org.spongepowered.asm.logging.LoggerAdapterAbstract
 import org.spongepowered.asm.mixin.MixinEnvironment
@@ -104,7 +103,8 @@ internal class DummyPropertyService : IGlobalPropertyService {
 }
 
 private typealias KlogLevel = me.xtrm.klog.Level
-private class WeaveLoggerAdapter(name: String) : LoggerAdapterAbstract(name) {
+
+class WeaveLoggerAdapter(name: String) : LoggerAdapterAbstract(name) {
     private val logger by klog(name)
     private val stdout = WeaveLogAppender.WrappingStream(System.out)
 

--- a/loader/src/main/kotlin/net/weavemc/loader/util/FileManager.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/util/FileManager.kt
@@ -1,11 +1,13 @@
 package net.weavemc.loader.util
 
+import me.xtrm.klog.dsl.klog
 import net.weavemc.internals.GameInfo
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.*
 
 internal object FileManager {
+    private val logger by klog
     val MODS_DIRECTORY = getOrCreateDirectory("mods")
     val DUMP_DIRECTORY = getOrCreateDirectory(".bytecode.out")
 
@@ -13,6 +15,7 @@ internal object FileManager {
         parts.joinToString(File.separator)
 
     fun getVanillaMinecraftJar(): File {
+        logger.trace("Searching for vanilla jar")
         val os = System.getProperty("os.name").lowercase()
         run {
             val userHome = System.getProperty("user.home", System.getenv("HOME") ?: System.getenv("USERPROFILE"))
@@ -32,6 +35,7 @@ internal object FileManager {
             }
         }
 
+        logger.trace("Trying to find vanilla jar in classpath")
         val gameVersion = GameInfo.version.versionName
         val mclPath = buildPath("versions", gameVersion, "$gameVersion.jar")
         val mmcPath = buildPath("libraries", "com", "mojang", "minecraft", gameVersion,
@@ -49,14 +53,16 @@ internal object FileManager {
     fun getMods(): List<ModJar> {
         val mods = mutableListOf<ModJar>()
 
+        logger.trace("Searching for mods in $MODS_DIRECTORY")
         mods += MODS_DIRECTORY.walkMods()
 
         val specificVersionDirectory = MODS_DIRECTORY.resolve(GameInfo.version.versionName)
         if (specificVersionDirectory.exists() && specificVersionDirectory.isDirectory()) {
+            logger.trace("Searching for mods in $specificVersionDirectory")
             mods += specificVersionDirectory.walkMods(true)
         }
 
-        println("Discovered ${mods.size} mod files")
+        logger.info("Discovered ${mods.size} mod files")
 
         return mods
     }

--- a/loader/src/main/kotlin/net/weavemc/loader/util/Mappings.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/util/Mappings.kt
@@ -1,6 +1,7 @@
 package net.weavemc.loader.util
 
 import com.grappenmaker.mappings.*
+import me.xtrm.klog.dsl.klog
 import net.weavemc.internals.GameInfo
 import net.weavemc.internals.MappingsRetrieval
 import net.weavemc.internals.MappingsType.MCP
@@ -19,14 +20,15 @@ import java.util.*
 import java.util.jar.JarFile
 
 object MappingsHandler {
+    private val logger by klog
     private val relocationVisitor by lazy { relocate() }
     private val vanillaJar by lazy {
         FileManager.getVanillaMinecraftJar()
     }
 
     val mergedMappings by lazy {
-        println("Loading merged mappings for ${GameInfo.version.versionName}")
-        println(" - Vanilla jar: $vanillaJar")
+        logger.info("Loading merged mappings for ${GameInfo.version.versionName}")
+        logger.debug("Vanilla jar: $vanillaJar")
         MappingsRetrieval.loadMergedWeaveMappings(GameInfo.version.versionName, vanillaJar)
     }
 

--- a/loader/src/main/kotlin/net/weavemc/loader/util/Mappings.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/util/Mappings.kt
@@ -171,7 +171,7 @@ private val relocationData: Properties by lazy {
 
 private fun relocate(): ((parent: ClassVisitor) -> ClassVisitor) {
     if (relocationData.isEmpty) {
-        println("Relocation data not found, skipping remapping.")
+        klog.warn("Relocation data not found, skipping remapping.")
         return { it }
     }
     val relocatePrefix = relocationData["target"].toString()

--- a/loader/src/main/kotlin/net/weavemc/loader/util/Utility.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/util/Utility.kt
@@ -1,6 +1,7 @@
 package net.weavemc.loader.util
 
 import kotlinx.serialization.json.Json
+import me.xtrm.klog.dsl.klog
 import net.weavemc.internals.GameInfo
 import net.weavemc.internals.ModConfig
 import org.objectweb.asm.ClassReader
@@ -131,7 +132,7 @@ inline fun <reified T> instantiate(className: String): T =
         ?: error("$className does not implement ${T::class.java.simpleName}!")
 
 internal fun fatalError(message: String): Nothing {
-    System.err.println("An error occurred: $message")
+    klog.fatal("An error occurred: $message")
     JOptionPane.showMessageDialog(
         /* parentComponent = */ null,
         /* message = */ "An error occurred: $message",
@@ -193,7 +194,7 @@ internal fun getJavaVersion(): Int {
 }
 
 fun JarFile.configOrFatal() = runCatching { fetchModConfig(JSON) }.onFailure {
-    println("Possibly non-weave mod failed to load:")
+    klog.error("Possibly non-weave mod failed to load:")
     it.printStackTrace()
 
     fatalError("Mod file ${this.name} is possibly not a Weave mod!")

--- a/loader/src/main/kotlin/net/weavemc/loader/util/Utility.kt
+++ b/loader/src/main/kotlin/net/weavemc/loader/util/Utility.kt
@@ -141,7 +141,6 @@ internal fun fatalError(message: String): Nothing {
     )
 
     exit(-1)
-    throw IllegalStateException("Exiting.")
 }
 
 /**
@@ -150,7 +149,7 @@ internal fun fatalError(message: String): Nothing {
  *
  * @param errorCode the error code to exit with
  */
-fun exit(errorCode: Int) {
+fun exit(errorCode: Int): Nothing {
     runCatching {
         val clazz = Class.forName("java.lang.Shutdown")
         clazz.getDeclaredMethod("exit", Int::class.javaPrimitiveType).apply {
@@ -172,6 +171,7 @@ fun exit(errorCode: Int) {
             }
         }
     }
+    throw IllegalStateException("This should never be reached")
 }
 
 private fun exitRuntime(errorCode: Int) {


### PR DESCRIPTION
This PR introduces [klog](https://codeberg.org/xtrm/klog) as a small logging library for Weave and mods to use.

The default logging level is `INFO`, meaning any log with a lower lever (like `DEBUG` or `TRACE`) isn't shown by default. To enable them, you can either:
- Change the global logging configuration via the `klog.config.defaultLevel` property
  - for example, launch with `-Dklog.config.defaultLevel=ALL` to see every log
- Change per-logger via their property `klog.logger.<name>.level`
  - for example, launch with `-Dklog.logger.mixin.level=NONE`

Note that the logger's level takes precedence over the global one.

Changes:
- Change all print statements to either use a `logger` instance or an instant logger via the `me.xtrm.klog.dsl.klog` property.
- Added some trace/debug statements throughout the project
- Added `net.weavemc.loader.bootstrap.WeaveLogAppender` to both write to the console and print to a logfile
  - the log files are located at `$HOME/.weave/logs`; this folder contains every Weave-Loader log (named `weave-loader-<date>-<time>.log`, as well as a `latest.log` file, which tries to hardlink/symlink to the latest log

Example PrismLauncher console output with `-Dklog.config.defaultLevel=ALL`:

![image](https://github.com/Weave-MC/Weave-Loader/assets/26600206/0d1bde12-a8ae-422b-8cc6-35f1f95560d5)
