### PR TITLE
fix: add new function to match the new sig of getClassNode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ kotlin.code.style  = official
 # Project properties
 projectName        = Weave-Loader
 projectGroup       = net.weavemc
-projectVersion     = 0.2.7
+projectVersion     = 0.2.8

--- a/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
+++ b/src/main/kotlin/net/weavemc/loader/bootstrap/Agent.kt
@@ -95,6 +95,7 @@ public fun premain(opt: String?, inst: Instrumentation) {
                 loader.loadClass("net.weavemc.loader.WeaveLoader")
                     .getDeclaredMethod("init", Instrumentation::class.java)
                     .invoke(null, inst)
+                println("[Weave] Initialized")
             }
 
             return null

--- a/src/main/kotlin/net/weavemc/loader/mixins/WeaveMixinService.kt
+++ b/src/main/kotlin/net/weavemc/loader/mixins/WeaveMixinService.kt
@@ -244,4 +244,9 @@ public class WeaveMixinService : IMixinService, IClassProvider, IClassBytecodePr
      */
     override fun getClassNode(name: String, runTransformers: Boolean): ClassNode =
         getClassNode(name)
+
+    // match sig fun getClassNode(String, Boolean, Int) to fix for latest lc
+    @Suppress("unused")
+    public fun getClassNode(name: String, runTransformers: Boolean, ignored: Int): ClassNode =
+        getClassNode(name)
 }


### PR DESCRIPTION
Add a new function with sig `getClassNode(String, Boolean, Int)` in WeaveMixinService.kt